### PR TITLE
Improve dark theme links and blockquotes

### DIFF
--- a/src/static/style.css
+++ b/src/static/style.css
@@ -441,6 +441,16 @@ input.has-error {
 .dark-theme .modal iframe {
   filter: invert(1);
 }
+.dark-theme a {
+  color: hsl(207, 90%, 54%);
+}
+.dark-theme a:visited {
+  color: hsl(277, 58%, 60%);
+}
+.dark-theme .card .view blockquote {
+  background: hsl(228, 14%, 26%);
+  border-color: hsl(0, 0%, 36%);
+}
 .gray-theme {
   --bg-left: hsl(202, 0%, 30%);
   --bg-main: hsl(202, 0%, 41%);
@@ -3331,7 +3341,7 @@ pre {
 }
 .card.active.has-children.flash {
   margin-right: -9px; /* to extend glow to the right*/
-  padding-right: 9px; 
+  padding-right: 9px;
 }
 .card.active.has-children.flash .card-right-overlay {
   margin-right: 9px;


### PR DESCRIPTION
This PR changes dark theme link colors to a bit lighter variants, so they're more easily readable. The blockquote background and border colors are also changed to a darker version since the text was previously completely unreadable.

**Before:**

<img width="495" alt="image" src="https://user-images.githubusercontent.com/12204005/155551174-9b698503-5b71-4b91-ad9c-31605ba02af0.png">

**After:**

<img width="495" alt="image" src="https://user-images.githubusercontent.com/12204005/155551129-545a55b9-d00b-4d24-9a60-ce41f8093128.png">
