### PR TITLE
enable link insertion shortcut

### DIFF
--- a/src/elm/Outgoing.elm
+++ b/src/elm/Outgoing.elm
@@ -53,6 +53,7 @@ type Msg
     | SelectAll String
     | FlashPrice
     | TextSurround String String
+    | InsertMarkdownLink String
     | SetField String String
     | SetCursorPosition Int
     | SetFullscreen Bool
@@ -206,6 +207,9 @@ send info =
 
         TextSurround id str ->
             dataToSend "TextSurround" (list string [ id, str ])
+        
+        InsertMarkdownLink id ->
+            dataToSend "InsertMarkdownLink" (string id)
 
         SetField id str ->
             dataToSend "SetField" (list string [ id, str ])

--- a/src/elm/Page/Doc.elm
+++ b/src/elm/Page/Doc.elm
@@ -733,6 +733,20 @@ incoming incomingMsg model =
                                 |> saveCardIfEditing
                                 |> insertAbove activeId beforeText
 
+                "mod+alt+k" ->
+                    case vs.viewMode of
+                        Normal _ ->
+                            ( model
+                            , Cmd.none
+                            , []
+                            )
+
+                        _ ->
+                            ( model
+                            , send (InsertMarkdownLink activeId)
+                            , []
+                            )
+
                 "mod+up" ->
                     normalMode model (insertAbove activeId "")
 
@@ -782,7 +796,7 @@ incoming incomingMsg model =
                 "mod+shift+down" ->
                     normalMode model (mergeDown activeId)
 
-                "mod+shift+k" ->
+                "mod+shift+k" -> 
                     normalMode model (mergeUp activeId)
 
                 "mod+shift+up" ->

--- a/src/shared/doc-helpers.js
+++ b/src/shared/doc-helpers.js
@@ -13,6 +13,15 @@ function toHex(s) {
   return h;
 }
 
+function isValidURL(text) {
+  try {
+      new URL(text);
+      return true;
+  } catch {
+      return false;
+  }
+}
+
 /* ===== DOM Manipulation ===== */
 let toElm;
 const CARD_DATA = Symbol.for("cardbased");
@@ -439,6 +448,7 @@ var shortcuts = [
   "mod+shift+down",
   "mod+shift+k",
   "mod+shift+up",
+  "mod+alt+k",
   "h",
   "j",
   "k",
@@ -599,6 +609,43 @@ var casesShared = (elmData, params) => {
 
         if (card !== null) {
           card.dataset.clonedContent = newValue
+        }
+      }
+    },
+
+    InsertMarkdownLink: () => {
+      const id = elmData
+      const tarea = document.getElementById('card-edit-' + id)
+      const card = document.getElementById('card-' + id)
+
+      if (tarea === null) {
+        console.log('Textarea not found for InsertMarkdownLink command.')
+      } else {
+        const start = tarea.selectionStart
+        const end = tarea.selectionEnd
+        const text = tarea.value.slice(start, end)
+
+        let modifiedText;
+        let cursorPos;
+        if (start !== end) {
+          if (isValidURL(text)) {
+            modifiedText = "[](" + text + ")"
+            newValue = tarea.value.substring(0, start) + modifiedText + tarea.value.substring(end)
+            cursorPos = start + 1
+          } else {
+            modifiedText = "[" + text + "]()"
+            newValue = tarea.value.substring(0, start) + modifiedText + tarea.value.substring(end)
+            cursorPos = start + modifiedText.length - 1
+          }
+          
+          tarea.value = newValue
+          tarea.setSelectionRange(cursorPos, cursorPos)
+          params.DIRTY = true
+          toElm(newValue, 'docMsgs', 'FieldChanged')
+          
+          if (card !== null) {
+            card.dataset.clonedContent = newValue
+          }
         }
       }
     },

--- a/src/shared/doc-helpers.js
+++ b/src/shared/doc-helpers.js
@@ -581,19 +581,24 @@ var casesShared = (elmData, params) => {
       } else {
         const start = tarea.selectionStart
         const end = tarea.selectionEnd
+        let cursorPos;
+        let newValue;
         if (start !== end) {
           const text = tarea.value.slice(start, end)
           const modifiedText = surroundString + text + surroundString
-          const newValue = tarea.value.substring(0, start) + modifiedText + tarea.value.substring(end)
-          tarea.value = newValue
-          const cursorPos = start + modifiedText.length
-          tarea.setSelectionRange(cursorPos, cursorPos)
-          params.DIRTY = true
-          toElm(newValue, 'docMsgs', 'FieldChanged')
+          newValue = tarea.value.substring(0, start) + modifiedText + tarea.value.substring(end)
+          cursorPos = start + modifiedText.length
+        } else {
+          newValue = tarea.value.substring(0, start) + surroundString + surroundString + tarea.value.substring(end)
+          cursorPos = start + surroundString.length
+        }
+        tarea.value = newValue
+        tarea.setSelectionRange(cursorPos, cursorPos)
+        params.DIRTY = true
+        toElm(newValue, 'docMsgs', 'FieldChanged')
 
-          if (card !== null) {
-            card.dataset.clonedContent = newValue
-          }
+        if (card !== null) {
+          card.dataset.clonedContent = newValue
         }
       }
     },


### PR DESCRIPTION
Made it so that Ctrl+B adds the needed asterisks and places the cursor between them, so no need to highlight text before bolding them. Same for italics.

Tests: I have only tested locally, without Cypress (I have not set up the testing yet).